### PR TITLE
Fix references to java

### DIFF
--- a/src/br/ufpe/cin/parser/JParser.java
+++ b/src/br/ufpe/cin/parser/JParser.java
@@ -17,8 +17,8 @@ import de.ovgu.cide.fstgen.ast.FSTNode;
 import de.ovgu.cide.fstgen.ast.FSTNonTerminal;
 
 /**
- * Class responsible for parsing java files, based on a 
- * <i>featurebnf</i> Java 1.8 annotated grammar: 
+ * Class responsible for parsing python files, based on a 
+ * <i>featurebnf</i> Python annotated grammar: 
  * {@link http://tinyurl.com/java18featurebnf}
  * For more information, see the documents in <i>guides</i> package.
  * @author Guilherme
@@ -26,9 +26,9 @@ import de.ovgu.cide.fstgen.ast.FSTNonTerminal;
 public class JParser {
 
 	/**
-	 * Parses a given .java file
+	 * Parses a given .py file
 	 * @param pythonFile
-	 * @return ast representing the java file
+	 * @return ast representing the python file
 	 * @throws ParseException 
 	 * @throws FileNotFoundException 
 	 * @throws UnsupportedEncodingException 
@@ -58,10 +58,10 @@ public class JParser {
 	{
 		if(FilesManager.readFileContent(file).isEmpty()){
 			throw new FileNotFoundException();
-		} else if(file != null && (isJavaFile(file) || JFSTMerge.isGit)){
+		} else if(file != null && (isPythonFile(file) || JFSTMerge.isGit)){
 			return true;
-		} else if(file != null && !isJavaFile(file)){
-			throw new ParseException("The file " + file.getName() + " is not a valid .java file.");
+		} else if(file != null && !isPythonFile(file)){
+			throw new ParseException("The file " + file.getName() + " is not a valid .py file.");
 		} else {
 			return false;
 		}
@@ -69,12 +69,12 @@ public class JParser {
 	
 
 	/**
-	 * Checks if a given file is a .java file.
+	 * Checks if a given file is a .py file.
 	 * @param file
-	 * @return true in case file extension is <i>java</i>, or false
+	 * @return true in case file extension is <i>python</i>, or false
 	 */
-	private boolean isJavaFile(File file){
+	private boolean isPythonFile(File file){
 		//return FilenameUtils.getExtension(file.getAbsolutePath()).equalsIgnoreCase("java");
-		return file.getName().toLowerCase().contains(".java");
+		return file.getName().toLowerCase().contains(".py");
 	}
 }

--- a/src/br/ufpe/cin/printers/Prettyprinter.java
+++ b/src/br/ufpe/cin/printers/Prettyprinter.java
@@ -121,7 +121,7 @@ public final class Prettyprinter {
 	private static FSTNonTerminal getCompilationUnit(FSTNode tree){
 		if(null != tree && tree instanceof FSTNonTerminal){
 			FSTNonTerminal node = (FSTNonTerminal)tree;
-			if(node.getType().equals("CompilationUnit")){
+			if(node.getType().equals("file_input")){
 				return node;
 			} else {
 				return node.getChildren().isEmpty()? null : getCompilationUnit(node.getChildren().get(1));


### PR DESCRIPTION
Change validation of files to check python extension instead of Java, and fix pretty printer to refer the Python grammar main entry production instead of Java's.